### PR TITLE
Emit string rather than returning nil

### DIFF
--- a/src/hello_cljsc/core.clj
+++ b/src/hello_cljsc/core.clj
@@ -212,8 +212,9 @@
 
 ;; Let's redefine foo, this time with two arities.
 (let [form (read1 "(defn foo ([a] a) ([a b] (+ a b)))")]
-  (env/with-compiler-env cenv
-    (c/emit (ana/analyze user-env form))))
+  (emit-str
+    (env/with-compiler-env cenv
+      (ana/analyze user-env form)))))
 
 ;; When you evaluate this, notice that the generated JavaScript is suboptimal.
 ;; First, it invokes cljs.user/foo through JavaScript's Function call method, which


### PR DESCRIPTION
This felt a bit jarring when suddenly a form evaluated to nil and required me to read the result in the console.
