### PR TITLE
Update to cljs 2411

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,4 +6,4 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-2138"]])
+                 [org.clojure/clojurescript "0.0-2411"]])

--- a/project.clj
+++ b/project.clj
@@ -5,5 +5,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/clojurescript "0.0-2138"]])

--- a/src/hello_cljsc/core.clj
+++ b/src/hello_cljsc/core.clj
@@ -147,7 +147,7 @@
 ;; When the ClojureScript compiler encounters an s-expression that
 ;; starts with a special form, it calls the cljs.analyer/parse multimethod.
 (let [form (read1 "(if x true false)")]
-  (pp/pprint (ana/parse (first form) user-env form nil)))
+  (pp/pprint (ana/parse (first form) user-env form nil nil)))
 
 ;; The following is copied and pasted from analyzer.clj
 ;;


### PR DESCRIPTION
Tutorial now works with clojure 1.6.0 and clojurescript 0.0-2411 after adjustment to account for change in cljs.analyzer/parse's arity.
